### PR TITLE
Update PC setup instructions and add GitHub link in localization files

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -48,9 +48,10 @@
   "somethingWentWrongErrorMessage": "Unknown error. Please try again or restart the app.",
 
   "pcSetup": "PC Setup",
-  "pcSetupDescription1": "Install \"TouchSender Tablet\" from the Windows Store",
+  "pcSetupDescription1": "Install \"TouchSenderTablet\" from GitHub",
   "pcSetupDescription2": "Set the same IP address and port number for both the PC app and this app",
   "pcSetupDescription3": "Start both the PC app and this app (order does not matter)",
+  "pcSetupGitHubLink": "TouchSenderTablet",
 
   "touchScreenRotation": "Rotatable touch screen",
   "touchScreenRotationDescription": "The direction of the mouse movement will automatically change according to the orientation of the screen.",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -48,9 +48,10 @@
   "somethingWentWrongErrorMessage": "未知のエラーが発生しました。アプリを再起動して再度お試しください。",
 
   "pcSetup": "PC側のセットアップ",
-  "pcSetupDescription1": "Windowsストアで「TouchSenderタブレット」をインストール",
+  "pcSetupDescription1": "GitHubから「TouchSenderTablet」をインストール",
   "pcSetupDescription2": "PCアプリと本アプリのIPアドレス・ポート番号を合わせて設定",
   "pcSetupDescription3": "PCアプリと本アプリをそれぞれ開始する（順不同）",
+  "pcSetupGitHubLink": "TouchSenderTablet",
 
   "touchScreenRotation": "回転可能なタッチ画面",
   "touchScreenRotationDescription": "画面の向きに合わせて、マウスカーソルの動く向きも自動的に変わります。",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -218,7 +218,7 @@ abstract class AppLocalizations {
   /// No description provided for @pcSetupDescription1.
   ///
   /// In en, this message translates to:
-  /// **'Install \"TouchSender Tablet\" from the Windows Store'**
+  /// **'Install \"TouchSenderTablet\" from GitHub'**
   String get pcSetupDescription1;
 
   /// No description provided for @pcSetupDescription2.
@@ -232,6 +232,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Start both the PC app and this app (order does not matter)'**
   String get pcSetupDescription3;
+
+  /// No description provided for @pcSetupGitHubLink.
+  ///
+  /// In en, this message translates to:
+  /// **'TouchSenderTablet'**
+  String get pcSetupGitHubLink;
 
   /// No description provided for @touchScreenRotation.
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -84,13 +84,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get pcSetup => 'PC Setup';
 
   @override
-  String get pcSetupDescription1 => 'Install \"TouchSender Tablet\" from the Windows Store';
+  String get pcSetupDescription1 => 'Install \"TouchSenderTablet\" from GitHub';
 
   @override
   String get pcSetupDescription2 => 'Set the same IP address and port number for both the PC app and this app';
 
   @override
   String get pcSetupDescription3 => 'Start both the PC app and this app (order does not matter)';
+
+  @override
+  String get pcSetupGitHubLink => 'TouchSenderTablet';
 
   @override
   String get touchScreenRotation => 'Rotatable touch screen';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -84,13 +84,16 @@ class AppLocalizationsJa extends AppLocalizations {
   String get pcSetup => 'PC側のセットアップ';
 
   @override
-  String get pcSetupDescription1 => 'Windowsストアで「TouchSenderタブレット」をインストール';
+  String get pcSetupDescription1 => 'GitHubから「TouchSenderTablet」をインストール';
 
   @override
   String get pcSetupDescription2 => 'PCアプリと本アプリのIPアドレス・ポート番号を合わせて設定';
 
   @override
   String get pcSetupDescription3 => 'PCアプリと本アプリをそれぞれ開始する（順不同）';
+
+  @override
+  String get pcSetupGitHubLink => 'TouchSenderTablet';
 
   @override
   String get touchScreenRotation => '回転可能なタッチ画面';

--- a/lib/main_screen/help_screen.dart
+++ b/lib/main_screen/help_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:touch_sender/l10n/app_localizations.dart';
 import 'package:touch_sender/util/logger.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class HelpScreen extends StatelessWidget {
   const HelpScreen({super.key});
@@ -28,6 +29,11 @@ class HelpScreen extends StatelessWidget {
                 AppLocalizations.of(context)!.pcSetupDescription3,
               ],
             ),
+            ElevatedButton.icon(
+              icon: const Icon(Icons.open_in_new),
+              onPressed: _launchGitHubURL,
+              label: Text(AppLocalizations.of(context)!.pcSetupGitHubLink),
+            ),
             HelpSimpleSection(
               icon: Icons.screen_rotation,
               title: AppLocalizations.of(context)!.touchScreenRotation,
@@ -50,6 +56,15 @@ class HelpScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+Future<void> _launchGitHubURL() async {
+  final url = Uri.parse(
+    'https://github.com/voltaney/TouchSenderTablet/releases',
+  );
+  if (!await launchUrl(url, mode: LaunchMode.externalApplication)) {
+    throw Exception('Could not launch $url');
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   collection: ^1.19.1
   flutter_launcher_icons: ^0.14.3
   cider: ^0.2.8
+  url_launcher: ^6.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request includes changes to update the localization text and add a new feature to launch a URL from the help screen. The most important changes include modifying the localization files to reflect the new source of the `TouchSenderTablet` app, adding a button to the help screen to open the GitHub page, and updating the dependencies to include the `url_launcher` package.

Localization updates:

* [`lib/l10n/app_en.arb`](diffhunk://#diff-9796fde3771f42a3a759ccc941731d83f96037a661e47dde27ce81d3447a69c2L51-R54): Updated the description text to indicate that the `TouchSenderTablet` app should be installed from GitHub instead of the Windows Store. Added a new localization key for the GitHub link.
* [`lib/l10n/app_ja.arb`](diffhunk://#diff-875d42c24d15b64d040a44c0c3d280e5d51086f5af5084834bc564855e089a1bL51-R54): Updated the description text to indicate that the `TouchSenderTablet` app should be installed from GitHub instead of the Windows Store. Added a new localization key for the GitHub link.
* [`lib/l10n/app_localizations.dart`](diffhunk://#diff-86a65e07f881bf3da78e06902f92759b712cf3c498529e6478a49914c85fa69eL221-R221): Updated the `AppLocalizations` abstract class to include the new localization key for the GitHub link. [[1]](diffhunk://#diff-86a65e07f881bf3da78e06902f92759b712cf3c498529e6478a49914c85fa69eL221-R221) [[2]](diffhunk://#diff-86a65e07f881bf3da78e06902f92759b712cf3c498529e6478a49914c85fa69eR236-R241)
* `lib/l10n/app_localizations_en.dart`, `lib/l10n/app_localizations_ja.dart`: Implemented the new localization key for the GitHub link in the English and Japanese localization classes. [[1]](diffhunk://#diff-e60f92e17bf4747aae4f57a00d2503eea8ce33d7d8366867ef7657259ec5845eL87-R97) [[2]](diffhunk://#diff-30636fa32bdc43e4694504987b0e206d65da1aaba4413476ff993480aee6d21eL87-R97)

Feature addition:

* [`lib/main_screen/help_screen.dart`](diffhunk://#diff-443d41ac76c969c43eb8e84d8943f1e1c42976eb3f2ea83b091c3f9afffa3353R4): Added a button to the help screen that launches the GitHub page for `TouchSenderTablet` using the `url_launcher` package. [[1]](diffhunk://#diff-443d41ac76c969c43eb8e84d8943f1e1c42976eb3f2ea83b091c3f9afffa3353R4) [[2]](diffhunk://#diff-443d41ac76c969c43eb8e84d8943f1e1c42976eb3f2ea83b091c3f9afffa3353R32-R36) [[3]](diffhunk://#diff-443d41ac76c969c43eb8e84d8943f1e1c42976eb3f2ea83b091c3f9afffa3353R62-R70)
* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25R54): Updated dependencies to include the `url_launcher` package.